### PR TITLE
Support partial `:locals`

### DIFF
--- a/lib/poirot/view.rb
+++ b/lib/poirot/view.rb
@@ -35,6 +35,7 @@ module Poirot
         instance_variable_set(name, instance_var)
         self[name.tr('@','').to_sym] = instance_var
       end
+      @locals ||= @renderer.instance_variable_get('@locals')
     end
   end
 end


### PR DESCRIPTION
Hey - great job with this library!  

I needed to render a _:collection_ of templates so I added support for _:locals_ as _@locals_.  I'm not sure an instance variable is the best way to handle local variables, but it's working well enough to share.

Hope this helps with _Issue #1: https://github.com/olivernn/poirot/issues/1_
