### PR TITLE
bugfix: correct usage of instance_variable code to reveal helper methods

### DIFF
--- a/lib/poirot/view.rb
+++ b/lib/poirot/view.rb
@@ -40,9 +40,8 @@ module Poirot
     end
 
     def method_missing(method_name, *args, &block)
-      instance_var = instance_variable_get("@#{method_name}")
-      if defined?(instance_var) && args.empty?
-        instance_var
+      if instance_variable_names.include?("@#{method_name}") && args.empty?
+        instance_variable_get("@#{method_name}")
       else
         view_context.send(method_name,*args, &block)
       end


### PR DESCRIPTION
At least in 1.9.2, instance_variable_get returns nil if there is no such instance variable, and defined?(nil) is truthy. This was preventing the "else" path from ever running and obscuring my normal rails helper methods.
