### PR TITLE
Fixed IE8 issue

### DIFF
--- a/vendor/assets/javascripts/poirot-base/poirot.js
+++ b/vendor/assets/javascripts/poirot-base/poirot.js
@@ -2,8 +2,8 @@ var poirot = (function ($) {
 
   var viewFactory = function (template, partials) {
     return function (data) {
-      return $(Mustache.to_html(template, data, partials))
-    }
+      return $(Mustache.to_html(template, data, partials));
+    };
   }
 
   var poirot = {
@@ -13,16 +13,16 @@ var poirot = (function ($) {
 
   $(document).ready(function () {
     $('script[type="text/mustache"]').each(function () {
-      var template = $(this).text()
+      var template = $(this).html();
       var methodName = this.id.replace(/-([a-z])/g, function (str) {
         return str.replace("-", "").toUpperCase()
-      }).replace("Template", "")
+      }).replace("Template", "");
 
-      poirot._partials[methodName] = template
+      poirot._partials[methodName] = template;
 
-      poirot[methodName] = poirot._viewFactory(template, poirot._partials)
+      poirot[methodName] = poirot._viewFactory(template, poirot._partials);
     })
   })
 
-  return poirot
-})(jQuery)
+  return poirot;
+})(jQuery);


### PR DESCRIPTION
There was an issue in `/vendor/assets/javascripts/poirot-base/poirot.js:16`: The method `text()` doesn't return anything in Internet Explorer < 9. I replaced it with the `html()` method and now it works.

I also added semicolons to the ends of the lines in this file as they are not optional in JavaScript.
