### PR TITLE
Changes the csrf token helper to use Ruby 1.8 safe syntax

### DIFF
--- a/lib/poirot/view_helper.rb
+++ b/lib/poirot/view_helper.rb
@@ -1,7 +1,7 @@
 module Poirot
   module ViewHelper
     def csrf_token
-      tag(:input, name: 'authenticity_token', type: 'hidden', value: form_authenticity_token)
+      tag(:input, :name => 'authenticity_token', :type => 'hidden', :value => form_authenticity_token)
     end
   end
 end


### PR DESCRIPTION
Didn't bump the version, I'll leave it to you nice chaps.
