### PR TITLE
replace rails dependency with railties

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     poirot (0.0.2)
       mustache
-      rails (> 3)
+      railties (> 3)
 
 GEM
   remote: http://rubygems.org/

--- a/poirot.gemspec
+++ b/poirot.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{mustaches}
   s.description = %q{mustaches are cool}
 
-  s.add_dependency('rails', '>3')
+  s.add_dependency('railties', '>3')
   s.add_dependency('mustache')
 
   s.rubyforge_project = "poirot"


### PR DESCRIPTION
This removes the rails dependency from the poirot and replaces it with railties.  This was tested using the example application.  

The rails dependency pulls in unnecessary gems such as activerecord, which is not needed if you are using another ORM.
