### PR TITLE
Partials can be included using the same names on the server side and on the client side

### DIFF
--- a/vendor/assets/javascripts/poirot-base/poirot.js
+++ b/vendor/assets/javascripts/poirot-base/poirot.js
@@ -21,6 +21,7 @@ var poirot = (function ($) {
         return str.replace("-", "_")
       }).replace("_template", "")
 
+      poirot._partials[methodName] = template
       poirot._partials[partialName] = template
 
       poirot[methodName] = poirot._viewFactory(template, poirot._partials)

--- a/vendor/assets/javascripts/poirot-base/poirot.js
+++ b/vendor/assets/javascripts/poirot-base/poirot.js
@@ -17,8 +17,11 @@ var poirot = (function ($) {
       var methodName = this.id.replace(/-([a-z])/g, function (str) {
         return str.replace("-", "").toUpperCase()
       }).replace("Template", "")
+      var partialName = "_" + this.id.replace(/-([a-z])/g, function (str) {
+        return str.replace("-", "_")
+      }).replace("_template", "")
 
-      poirot._partials[methodName] = template
+      poirot._partials[partialName] = template
 
       poirot[methodName] = poirot._viewFactory(template, poirot._partials)
     })


### PR DESCRIPTION
This pull request makes it possible to include partials on the server side and on the client side using the same partial names.

To illustrate this, lets say we had partial _my_stuff.html.mustache. On the server side this partial needed to be included using {{> _my_stuff }}. However, on client side this partial needed to be included using {{> myStuff }}. The names of the partials on the client side was that same as the poirot rendering functions.

The second commit adds backwards compatibility for the old naming if that is needed.
