### PR TITLE
Remove left spaces when passing HTML to jQuery 1.9

### DIFF
--- a/vendor/assets/javascripts/poirot-base/poirot.js
+++ b/vendor/assets/javascripts/poirot-base/poirot.js
@@ -2,7 +2,7 @@ var poirot = (function ($) {
 
   var viewFactory = function (template, partials) {
     return function (data) {
-      return $(Mustache.to_html(template, data, partials))
+      return $($.parseHTML(Mustache.to_html(template, data, partials)))
     }
   }
 


### PR DESCRIPTION
Passing mustache generated HTML with left spaces to jQuery results in an error.
The proposed change implements a solution based on http://stage.jquery.com/upgrade-guide/1.9/#jquery-htmlstring-versus-jquery-selectorstring
